### PR TITLE
Increase PIC clause size for hello-world

### DIFF
--- a/exercises/practice/hello-world/.meta/proof.ci.CBL
+++ b/exercises/practice/hello-world/.meta/proof.ci.CBL
@@ -3,7 +3,7 @@
         PROGRAM-ID. hello.
         DATA DIVISION.
         WORKING-STORAGE SECTION.
-        01 WS-RESULT PIC X(13).
+        01 WS-RESULT PIC X(14).
         PROCEDURE DIVISION.
         HELLO-WORLD.
             MOVE "Hello, World!" TO WS-RESULT.

--- a/exercises/practice/hello-world/src/hello-world.CBL
+++ b/exercises/practice/hello-world/src/hello-world.CBL
@@ -3,7 +3,7 @@
        PROGRAM-ID. hello-world.
        DATA DIVISION.
        WORKING-STORAGE SECTION.
-       01 WS-RESULT PIC X(13).
+       01 WS-RESULT PIC X(14).
        PROCEDURE DIVISION.
        HELLO-WORLD.
         MOVE "Goodbye, Mars!" TO WS-RESULT.

--- a/exercises/practice/hello-world/tst/hello-world/hello-world.cut
+++ b/exercises/practice/hello-world/tst/hello-world/hello-world.cut
@@ -1,5 +1,5 @@
 TestCase "Hello World"
 	MOVE SPACES TO WS-RESULT
 	PERFORM HELLO-WORLD
-	EXPECT WS-RESULT = "Hello, World!"
+	EXPECT WS-RESULT = "Hello, World! "
 


### PR DESCRIPTION
This PR increases the PIC clause size from 13 to 14 for the hello-world exercise.

**Background:**
`Goodbye, Mars!` is 14 characters long. A curious course takers may decide to `DISPLAY WS-RESULT` and may be confused when the exclamation mark is not showing as it is truncated due to `PIC X(13)`.

**Possible Issue:**
It is possible that someone with prior COBOL knowledge would adjust the PIC clause while also changing the string to `Hello, World!`. It could be that the checking may fail in that case as it would now expect a trailing whitespace due to the change in PIC size. However, as I'm aware, the hello-world challenge is intended to have no prerequisite at all, and it may be more convenience to go this route rather than trying to explain PIC clause sizes at the moment.