### PR TITLE
test.ps1 fixes

### DIFF
--- a/exercises/practice/hello-world/test.ps1
+++ b/exercises/practice/hello-world/test.ps1
@@ -1,14 +1,15 @@
 if (![System.IO.File]::Exists("$PSScriptRoot/bin/cobolcheck.exe")){
-  Write-Output "Cobolcheck not found, try to fetch it."
+  Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot/bin/fetch-cobolcheck.ps1"
 }
 
 Write-Output "Run cobolcheck."
-cd $PSScriptRoot
+Set-Location $PSScriptRoot
 
 
-Invoke-Expression "bin/cobolcheck.exe -p hello-world -l debug && cobc -x TEST.CBL && TEST.exe"
-    
+Invoke-Expression "bin/cobolcheck.exe -p hello-world"
+Invoke-Expression "cobc -xj TEST.CBL"
+
 if ($Lastexitcode -ne 0) {
   exit $Lastexitcode
 }


### PR DESCRIPTION
* Changed `cd` to `Set-Location`
* Removed debug logging from cobolcheck invocation
* Improved English
* Separated compile from check
* Compile goes straight to run using `-j`

All this after actually downloading the exercise the way a student would, with `exercism download --track=cobol --exercise=hello-world`