### PR TITLE
[fix]: No manual effort for test scripts needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ test.exe
 output
 *Log.txt
 cobolcheck.exe
-*.cbl.bak
+*.cob.bak

--- a/exercises/practice/hello-world/bin/fetch-cobolcheck
+++ b/exercises/practice/hello-world/bin/fetch-cobolcheck
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
-# set -eo pipefail
+set -eo pipefail
 
 readonly LATEST='https://api.github.com/repos/0xE282B0/cobol-check/releases/latest'
 

--- a/exercises/practice/hello-world/bin/fetch-cobolcheck.ps1
+++ b/exercises/practice/hello-world/bin/fetch-cobolcheck.ps1
@@ -1,7 +1,6 @@
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1 file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks
-# benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"

--- a/exercises/practice/hello-world/test.ps1
+++ b/exercises/practice/hello-world/test.ps1
@@ -1,3 +1,5 @@
+$slug=Split-Path $PSScriptRoot -Leaf
+
 if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
@@ -6,7 +8,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p hello-world"
+Invoke-Expression "bin\cobolcheck.exe -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/hello-world/test.sh
+++ b/exercises/practice/hello-world/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
+SLUG=$(basename "${SCRIPT_DIR}")
 
 if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
@@ -7,7 +8,7 @@ if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p hello-world
+./bin/cobolcheck -p $SLUG
 
 # compile and run
 cobc -xj test.cob

--- a/exercises/practice/isogram/bin/fetch-cobolcheck
+++ b/exercises/practice/isogram/bin/fetch-cobolcheck
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
-# set -eo pipefail
+set -eo pipefail
 
 readonly LATEST='https://api.github.com/repos/0xE282B0/cobol-check/releases/latest'
 

--- a/exercises/practice/isogram/bin/fetch-cobolcheck.ps1
+++ b/exercises/practice/isogram/bin/fetch-cobolcheck.ps1
@@ -1,7 +1,6 @@
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1 file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks
-# benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"

--- a/exercises/practice/isogram/test.ps1
+++ b/exercises/practice/isogram/test.ps1
@@ -1,13 +1,14 @@
+$slug=Split-Path $PSScriptRoot -Leaf
+
 if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
-  Write-Output "Cobolcheck not found. Trying to fetch it."  
+  Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
 
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-
-Invoke-Expression "bin\cobolcheck.exe -p isogram"
+Invoke-Expression "bin\cobolcheck.exe -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/isogram/test.sh
+++ b/exercises/practice/isogram/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
+SLUG=$(basename "${SCRIPT_DIR}")
 
 if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
@@ -7,6 +8,7 @@ if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p isogram
+./bin/cobolcheck -p $SLUG
+
 # compile and run
 cobc -xj test.cob

--- a/exercises/practice/leap/bin/fetch-cobolcheck
+++ b/exercises/practice/leap/bin/fetch-cobolcheck
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
-# set -eo pipefail
+set -eo pipefail
 
 readonly LATEST='https://api.github.com/repos/0xE282B0/cobol-check/releases/latest'
 

--- a/exercises/practice/leap/bin/fetch-cobolcheck.ps1
+++ b/exercises/practice/leap/bin/fetch-cobolcheck.ps1
@@ -1,7 +1,6 @@
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1 file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks
-# benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"

--- a/exercises/practice/leap/test.ps1
+++ b/exercises/practice/leap/test.ps1
@@ -1,13 +1,14 @@
+$slug=Split-Path $PSScriptRoot -Leaf
+
 if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
-  Write-Output "Cobolcheck not found. Trying to fetch it."  
+  Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
 
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-
-Invoke-Expression "bin\cobolcheck.exe -p leap"
+Invoke-Expression "bin\cobolcheck.exe -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/leap/test.sh
+++ b/exercises/practice/leap/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
+SLUG=$(basename "${SCRIPT_DIR}")
 
 if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
@@ -7,6 +8,7 @@ if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p leap
+./bin/cobolcheck -p $SLUG
+
 # compile and run
 cobc -xj test.cob

--- a/exercises/practice/pangram/bin/fetch-cobolcheck
+++ b/exercises/practice/pangram/bin/fetch-cobolcheck
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
-# set -eo pipefail
+set -eo pipefail
 
 readonly LATEST='https://api.github.com/repos/0xE282B0/cobol-check/releases/latest'
 

--- a/exercises/practice/pangram/bin/fetch-cobolcheck.ps1
+++ b/exercises/practice/pangram/bin/fetch-cobolcheck.ps1
@@ -1,7 +1,6 @@
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1 file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks
-# benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"

--- a/exercises/practice/pangram/test.ps1
+++ b/exercises/practice/pangram/test.ps1
@@ -1,13 +1,14 @@
+$slug=Split-Path $PSScriptRoot -Leaf
+
 if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
-  Write-Output "Cobolcheck not found. Trying to fetch it."  
+  Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
 
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-
-Invoke-Expression "bin\cobolcheck.exe -p pangram"
+Invoke-Expression "bin\cobolcheck.exe -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/pangram/test.sh
+++ b/exercises/practice/pangram/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
+SLUG=$(basename "${SCRIPT_DIR}")
 
 if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
@@ -7,6 +8,7 @@ if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p pangram
+./bin/cobolcheck -p $SLUG
+
 # compile and run
 cobc -xj test.cob

--- a/exercises/practice/yacht/bin/fetch-cobolcheck
+++ b/exercises/practice/yacht/bin/fetch-cobolcheck
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
-# set -eo pipefail
+set -eo pipefail
 
 readonly LATEST='https://api.github.com/repos/0xE282B0/cobol-check/releases/latest'
 

--- a/exercises/practice/yacht/bin/fetch-cobolcheck.ps1
+++ b/exercises/practice/yacht/bin/fetch-cobolcheck.ps1
@@ -1,7 +1,6 @@
-# This file is a copy of the
-# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1 file.
-# Please submit bugfixes/improvements to the above file to ensure that all tracks
-# benefit from the changes.
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
 
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"

--- a/exercises/practice/yacht/test.ps1
+++ b/exercises/practice/yacht/test.ps1
@@ -1,12 +1,14 @@
+$slug=Split-Path $PSScriptRoot -Leaf
+
 if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
-  & "$PSScriptRoot/bin/fetch-cobolcheck.ps1"
+  & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
 
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p yacht"
+Invoke-Expression "bin\cobolcheck.exe -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/yacht/test.sh
+++ b/exercises/practice/yacht/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/
+SLUG=$(basename "${SCRIPT_DIR}")
 
 if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     echo "Cobolcheck not found, try to fetch it."
@@ -7,7 +8,7 @@ if [ ! -f $SCRIPT_DIR/bin/cobolcheck ]; then
     ./fetch-cobolcheck
 fi
 cd $SCRIPT_DIR
-./bin/cobolcheck -p yacht
+./bin/cobolcheck -p $SLUG
 
 # compile and run
 cobc -xj test.cob


### PR DESCRIPTION
- `test.sh` and `test.ps1` now can be copied and do not need modification anymore. The name of the test is taken from the folder name.
- comments in fetch scripts are adapted to meet exercism/cobo#29

Signed-off-by: Sven Pfennig <s.pfennig@reply.de>