### PR TITLE
[Fix]: Fixed SNIPPET.txt to display correctly on the website

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,8 +1,7 @@
-      *COBOL source code snippet
+HELLO * COBOL source code snippet
        IDENTIFICATION DIVISION.
        PROGRAM-ID. Hello.
        DATA DIVISION.
        PROCEDURE DIVISION.
-         DISPLAY "Hello World!"
-         STOP RUN.
-       
+       DISPLAY "Hello World!"
+       STOP RUN.


### PR DESCRIPTION
It seems that Exercism removes all leading spaces at the start of the first line, and that causes the comment on the first line to not display correctly.

![Screen Shot 2022-07-24 at 10 42 48](https://user-images.githubusercontent.com/73310001/180649868-225e9bae-2179-4f57-b9e7-cd5fc00a0b61.png)
---
So I added a `HELLO` at the start of the sequence number area to try and keep the comment formatting.