### PR TITLE
Fix/linux ci version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup COBOL
-        uses: fabasoad/setup-cobol-action@0e90d7d30a6c2dc4e4992c713c7c9a7d8ea677a9
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install curl tar libncurses5-dev libgmp-dev libdb-dev
+          sudo apt-get -y autoremove
+          sudo apt-get -y install iproute2
+
+          sudo apt-get -y install ranger autoconf build-essential
+          curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.1/gnucobol-3.1.2.tar.gz | tar xz
+          cd gnucobol-3.1.2 && ./configure --prefix=/usr && sudo make && sudo make install && sudo ldconfig
+          sudo apt-get -y --purge autoremove
 
       - name: Run tests for all exercises
         run: bin/test

--- a/exercises/practice/two-fer/.meta/proof.ci.cob
+++ b/exercises/practice/two-fer/.meta/proof.ci.cob
@@ -11,8 +11,7 @@
        IF WS-NAME EQUAL SPACE THEN
            MOVE "One for you, one for me." TO WS-RESULT
        ELSE
-           STRING "One for "
-           FUNCTION TRIM(WS-NAME TRAILING) 
-           ", one for me."
-           INTO WS-RESULT
+           MOVE FUNCTION CONCAT("One for ", 
+           FUNCTION TRIM(WS-NAME TRAILING),", one for me.") 
+           TO WS-RESULT
        END-IF.


### PR DESCRIPTION
Since the version is hardcoded in the GitHub Action we are using, I needed to extract the code to setup gnucobol from here: https://github.com/fabasoad/setup-cobol-action/blob/main/src/install-cobol-linux.sh

I will raise a PR to make the version configurable on that action but for now, we can use 3.1.2 features.

@KTSnowy