### PR TITLE
[Update]: Change indentation size for the online editor

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4,
+    "indent_size": 3,
     "highlightjs_language": "cobol"
   },
     "test_runner": {


### PR DESCRIPTION
This PR changes the tab indentation size from 4 spaces to 3 spaces on the online editor.

I've noticed that when pressing the tab key twice I end up missing the correct column by 1 space, and when trying to delete that one space it ends up deleting the full 4 space tab. That might be a little annoying for students.

With 3 spaces it would end up in the 7th column (indicator area) and requiring one more space to get to the correct column to start coding. 