### PR TITLE
[Fix?] Attempt to unstuck Hamming exercise

### DIFF
--- a/exercises/practice/hamming/test.sh
+++ b/exercises/practice/hamming/test.sh
@@ -18,3 +18,4 @@ $COBOLCHECK -p $SLUG
 # compile and run
 echo "COMPILE AND RUN TEST"
 cobc -xj test.cob
+


### PR DESCRIPTION
In an attempt to unstuck the Hamming Distance exercise I'm adding an empty new line at the end of the test.sh file. 

Maybe pushing an update will fix and unstuck the exercise from not being able to update.