### PR TITLE
[Fix?]: Add a trailing space to unstuck Leap exercise

### DIFF
--- a/exercises/practice/leap/test.sh
+++ b/exercises/practice/leap/test.sh
@@ -15,6 +15,6 @@ fi
 cd $SCRIPT_DIR
 $COBOLCHECK -p $SLUG
 
-# compile and run
+# compile and run 
 echo "COMPILE AND RUN TEST"
 cobc -xj test.cob


### PR DESCRIPTION
Hey @axtens this same issue happened with the Hamming exercise and it was fixed by pushing an update. So this PR might be able to fix the Leap exercise issue for you as well.