### PR TITLE
Remove reference to Gitter

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -42,8 +42,6 @@ Choose your current OS:
 
 Good luck, have fun and welcome to the COBOL track!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
-
 ----
 
 ## macOS
@@ -78,9 +76,6 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 Good luck, have fun and welcome to the COBOL track!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
-
-
 ----
 
 ## Linux
@@ -112,5 +107,3 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 
 Good luck, have fun and welcome to the COBOL track!
-
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -42,8 +42,6 @@ Choose your current OS:
 
 Good luck, have fun and welcome to the COBOL track!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
-
 ----
 
 ## macOS
@@ -78,9 +76,6 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 Good luck, have fun and welcome to the COBOL track!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
-
-
 ----
 
 ## Linux
@@ -112,5 +107,3 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 
 Good luck, have fun and welcome to the COBOL track!
-
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
