### PR TITLE
Sync fetch-configlet.ps1 script

### DIFF
--- a/bin/fetch-configlet.ps1
+++ b/bin/fetch-configlet.ps1
@@ -12,20 +12,31 @@ $requestOpts = @{
     RetryIntervalSec  = 1
 }
 
-$arch = If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
-$fileName = "configlet-windows-$arch.zip"
-
 Function Get-DownloadUrl {
+    $arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
-    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts
-    | Select-Object -ExpandProperty assets
-    | Where-Object { $_.browser_download_url -match $FileName }
-    | Select-Object -ExpandProperty browser_download_url
+    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts `
+    | Select-Object -ExpandProperty assets `
+    | Where-Object { $_.name -match "^configlet_.+_windows_${arch}.zip$" } `
+    | Select-Object -ExpandProperty browser_download_url -First 1
 }
 
-$downloadUrl = Get-DownloadUrl
 $outputDirectory = "bin"
-$outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
-Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
-Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
-Remove-Item -Path $outputFile
+if (!(Test-Path -Path $outputDirectory)) {
+    Write-Output "Error: no ./bin directory found. This script should be ran from a repo root."
+    exit 1
+}
+
+Write-Output "Fetching configlet..."
+$downloadUrl = Get-DownloadUrl
+$outputFileName = "configlet.zip"
+$outputPath = Join-Path -Path $outputDirectory -ChildPath $outputFileName
+Invoke-WebRequest -Uri $downloadUrl -OutFile $outputPath @requestOpts
+
+$configletPath = Join-Path -Path $outputDirectory -ChildPath "configlet.exe"
+if (Test-Path -Path $configletPath) { Remove-Item -Path $configletPath }
+[System.IO.Compression.ZipFile]::ExtractToDirectory($outputPath, $outputDirectory)
+Remove-Item -Path $outputPath
+
+$configletVersion = (Select-String -Pattern "/releases/download/(.+?)/" -InputObject $downloadUrl -AllMatches).Matches.Groups[1].Value
+Write-Output "Downloaded configlet ${configletVersion} to ${configletPath}"


### PR DESCRIPTION
This PR updates the bin/fetch-configlet.ps1 script to the latest version. This fixes the issue mentioned in this forum post: https://forum.exercism.org/t/problem-running-the-powershell-version-of-fetch-configlet/8383.

References https://github.com/exercism/configlet/issues/839