### PR TITLE
Pre-fetch cobolcheck

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -55,14 +55,17 @@ jobs:
         shell: pwsh
         run: bin/fetch-cobolcheck.ps1
 
-      - name: Run tests for all exercises
+      - name: Setup environment
         shell: pwsh
         run: |
-          $env:Path = "D:\a\cobol\cobol\gnucobol\bin;" + $env:Path
+          $env:Path = "D:\a\cobol\cobol\gnucobol\bin;$HOME\bin;" + $env:Path
           [System.Environment]::SetEnvironmentVariable('COB_CONFIG_DIR', 'D:\a\cobol\cobol\gnucobol\config')
           [System.Environment]::SetEnvironmentVariable('COB_COPY_DIR', 'D:\a\cobol\cobol\gnucobol\copy')
           [System.Environment]::SetEnvironmentVariable('COB_CFLAGS', '-I D:\a\cobol\cobol\gnucobol\include')
           [System.Environment]::SetEnvironmentVariable('COB_LDFLAGS', '-L D:\a\cobol\cobol\gnucobol\lib')
           [System.Environment]::SetEnvironmentVariable('COB_LIBRARY_PATH', 'D:\a\cobol\cobol\gnucobol\lib')
           [System.Environment]::SetEnvironmentVariable('COB_LIBS', 'D:\a\cobol\cobol\gnucobol\bin\libcob-4.dll')
-          bin/test.ps1
+
+      - name: Run tests for all exercises
+        shell: pwsh
+        run: bin/test.ps1

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
-      
       - name: Cache GnuCOBOL
         id: cache-gnu-cobol
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
@@ -51,6 +50,10 @@ jobs:
       - name: Extract GnuCOBOL
         shell: pwsh
         run: Expand-Archive ~\gnucobol-3.2-dev.zip -DestinationPath gnucobol -Force
+
+      - name: Fetch CobolCheck
+        shell: pwsh
+        run: bin/fetch-cobolcheck.ps1
 
       - name: Run tests for all exercises
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,8 @@ jobs:
           curl -sLk https://sourceforge.net/projects/open-cobol/files/gnu-cobol/3.1/gnucobol-3.1.2.tar.gz | tar xz
           cd gnucobol-3.1.2 && ./configure --prefix=/usr && sudo make && sudo make install && sudo ldconfig
 
+      - name: Fetch CobolCheck
+        run: bin/fetch-cobolcheck
+
       - name: Run tests for all exercises
         run: bin/test

--- a/bin/fetch-cobolcheck
+++ b/bin/fetch-cobolcheck
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
+
+set -eo pipefail
+
+readonly LATEST='https://api.github.com/repos/0xE282B0/cobol-check/releases/latest'
+
+case "$(uname)" in
+  Darwin*)   os='mac'     ;;
+  Linux*)    os='linux'   ;;
+  Windows*)  os='windows' ;;
+  MINGW*)    os='windows' ;;
+  MSYS_NT-*) os='windows' ;;
+  *)         os='linux'   ;;
+esac
+
+case "${os}" in
+  windows*) ext='.exe' ;;
+  *)        ext='' ;;
+esac
+
+arch="$(uname -m)"
+
+curlopts=(
+  --silent
+  --show-error
+  --fail
+  --location
+  --retry 3
+)
+
+if [[ -n "${GITHUB_TOKEN}" ]]; then
+  curlopts+=(--header "authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+suffix="${os}-${arch}${ext}"
+
+get_download_url() {
+  curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
+    grep "\"browser_download_url\": \".*/download/.*/cobol-check.*${suffix}\"$" |
+    cut -d'"' -f4
+}
+
+main() {
+  output_path="/usr/local/bin/cobolcheck${ext}"
+  download_url="$(get_download_url)"
+  curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
+  chmod +x "${output_path}"
+}
+
+main

--- a/bin/fetch-cobolcheck.ps1
+++ b/bin/fetch-cobolcheck.ps1
@@ -23,5 +23,7 @@ Function Get-DownloadUrl {
 }
 
 $downloadUrl = Get-DownloadUrl
-$outputFile = Join-Path -Path "${HOME}\cobol\gnucobol\bin" -ChildPath "cobolcheck.exe"
+$outputDir = Join-Path -Path $HOME -ChildPath "bin"
+$outputFile = Join-Path -Path $outputDir -ChildPath "cobolcheck.exe"
+New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
 Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts

--- a/bin/fetch-cobolcheck.ps1
+++ b/bin/fetch-cobolcheck.ps1
@@ -1,0 +1,28 @@
+# This file is inspired by https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1.
+# It is only used in the cobol track, and a copy of it is placed in every exercise folder.
+# If you change something, make sure to upgrade all scripts in all exercises!
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$requestOpts = @{
+    Headers           = If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
+    MaximumRetryCount = 3
+    RetryIntervalSec  = 1
+}
+
+$arch = If ([Environment]::Is64BitOperatingSystem) { "amd64" } Else { "x86" }
+$fileName = "cobol-check-windows-$arch.exe"
+
+Function Get-DownloadUrl {
+    $latestUrl = "https://api.github.com/repos/0xE282B0/cobol-check/releases/latest"
+    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts
+    | Select-Object -ExpandProperty assets
+    | Where-Object { $_.browser_download_url -match $FileName }
+    | Select-Object -ExpandProperty browser_download_url
+}
+
+$downloadUrl = Get-DownloadUrl
+$outputFile = Join-Path -Path $PSScriptRoot -ChildPath "cobolcheck.exe"
+Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";" + $PSScriptRoot, "Machine")

--- a/bin/fetch-cobolcheck.ps1
+++ b/bin/fetch-cobolcheck.ps1
@@ -23,6 +23,5 @@ Function Get-DownloadUrl {
 }
 
 $downloadUrl = Get-DownloadUrl
-$outputFile = Join-Path -Path $PSScriptRoot -ChildPath "cobolcheck.exe"
+$outputFile = Join-Path -Path "${HOME}\cobol\gnucobol\bin" -ChildPath "cobolcheck.exe"
 Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";" + $PSScriptRoot, "Machine")

--- a/exercises/practice/acronym/test.ps1
+++ b/exercises/practice/acronym/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/all-your-base/test.ps1
+++ b/exercises/practice/all-your-base/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/allergies/test.ps1
+++ b/exercises/practice/allergies/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/armstrong-numbers/test.ps1
+++ b/exercises/practice/armstrong-numbers/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/atbash-cipher/test.ps1
+++ b/exercises/practice/atbash-cipher/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/binary/test.ps1
+++ b/exercises/practice/binary/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/bob/test.ps1
+++ b/exercises/practice/bob/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/circular-buffer/test.ps1
+++ b/exercises/practice/circular-buffer/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/collatz-conjecture/test.ps1
+++ b/exercises/practice/collatz-conjecture/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/complex-numbers/test.ps1
+++ b/exercises/practice/complex-numbers/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/darts/test.ps1
+++ b/exercises/practice/darts/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/difference-of-squares/test.ps1
+++ b/exercises/practice/difference-of-squares/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/hamming/test.ps1
+++ b/exercises/practice/hamming/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/hello-world/test.ps1
+++ b/exercises/practice/hello-world/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/high-scores/test.ps1
+++ b/exercises/practice/high-scores/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/isogram/test.ps1
+++ b/exercises/practice/isogram/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/leap/test.ps1
+++ b/exercises/practice/leap/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/luhn/test.ps1
+++ b/exercises/practice/luhn/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/matching-brackets/test.ps1
+++ b/exercises/practice/matching-brackets/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/nucleotide-count/test.ps1
+++ b/exercises/practice/nucleotide-count/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/pangram/test.ps1
+++ b/exercises/practice/pangram/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/pascals-triangle/test.ps1
+++ b/exercises/practice/pascals-triangle/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/queen-attack/test.ps1
+++ b/exercises/practice/queen-attack/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/raindrops/test.ps1
+++ b/exercises/practice/raindrops/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/reverse-string/test.ps1
+++ b/exercises/practice/reverse-string/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/rna-transcription/test.ps1
+++ b/exercises/practice/rna-transcription/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/roman-numerals/test.ps1
+++ b/exercises/practice/roman-numerals/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/rotational-cipher/test.ps1
+++ b/exercises/practice/rotational-cipher/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/scrabble-score/test.ps1
+++ b/exercises/practice/scrabble-score/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/sieve/test.ps1
+++ b/exercises/practice/sieve/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/square-root/test.ps1
+++ b/exercises/practice/square-root/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/triangle/test.ps1
+++ b/exercises/practice/triangle/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/two-fer/test.ps1
+++ b/exercises/practice/two-fer/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {

--- a/exercises/practice/yacht/test.ps1
+++ b/exercises/practice/yacht/test.ps1
@@ -1,6 +1,11 @@
 $slug=Split-Path $PSScriptRoot -Leaf
+$cobolcheck = "$PSScriptRoot\bin\cobolcheck.exe"
+$cobolcheckCmd = Get-Command "cobolcheck.exe" -ErrorAction SilentlyContinue
 
-if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
+if ($cobolcheckCmd) {
+  $cobolcheck = $cobolcheckCmd.Path
+  Write-Output "Found cobolcheck, using $cobolcheck"
+} elseif (![System.IO.File]::Exists("$cobolcheck")){
   Write-Output "Cobolcheck not found. Trying to fetch it."
   & "$PSScriptRoot\bin\fetch-cobolcheck.ps1"
 }
@@ -8,7 +13,7 @@ if (![System.IO.File]::Exists("$PSScriptRoot\bin\cobolcheck.exe")){
 Write-Output "Run cobolcheck."
 Set-Location $PSScriptRoot
 
-Invoke-Expression "bin\cobolcheck.exe -p $slug"
+Invoke-Expression "$cobolcheck -p $slug"
 Invoke-Expression "cobc -xj test.cob"
 
 if ($Lastexitcode -ne 0) {


### PR DESCRIPTION
@axtens There was code to use a pre-fetched cobolcheck in each exercise's `test.sh` file, but CI never downloaded it. This PR does that, and also applies the same logic to the powershell version. It did mean that I needed to add that extra "check if the file is already there" check to each exercise's `test.ps1` script.