### PR TITLE
Missing variable

### DIFF
--- a/exercises/practice/grade-school/src/grade-school.cob
+++ b/exercises/practice/grade-school/src/grade-school.cob
@@ -5,6 +5,7 @@
        WORKING-STORAGE SECTION.
        01 WS-STUDENTNAME           PIC X(60).
        01 WS-STUDENTGRADE          PIC 9.
+       01 WS-DESIREDGRADE          PIC 9.
        01 WS-RESULT                PIC X(5).
        
        01 STUDENTROSTER.


### PR DESCRIPTION
WS-DESIREDGRADE is required by the tests, and should be available from the start, to allow all tests to fail from the start, instead of receiving compile errors.