### PR TITLE
Fix fetch-cobolcheck user-only download

### DIFF
--- a/bin/fetch-cobolcheck
+++ b/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/acronym/bin/fetch-cobolcheck
+++ b/exercises/practice/acronym/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/all-your-base/bin/fetch-cobolcheck
+++ b/exercises/practice/all-your-base/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/allergies/bin/fetch-cobolcheck
+++ b/exercises/practice/allergies/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/anagram/bin/fetch-cobolcheck
+++ b/exercises/practice/anagram/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/armstrong-numbers/bin/fetch-cobolcheck
+++ b/exercises/practice/armstrong-numbers/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/atbash-cipher/bin/fetch-cobolcheck
+++ b/exercises/practice/atbash-cipher/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/binary-search/bin/fetch-cobolcheck
+++ b/exercises/practice/binary-search/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/binary/bin/fetch-cobolcheck
+++ b/exercises/practice/binary/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/bob/bin/fetch-cobolcheck
+++ b/exercises/practice/bob/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/circular-buffer/bin/fetch-cobolcheck
+++ b/exercises/practice/circular-buffer/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/collatz-conjecture/bin/fetch-cobolcheck
+++ b/exercises/practice/collatz-conjecture/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/complex-numbers/bin/fetch-cobolcheck
+++ b/exercises/practice/complex-numbers/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/darts/bin/fetch-cobolcheck
+++ b/exercises/practice/darts/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/diamond/bin/fetch-cobolcheck
+++ b/exercises/practice/diamond/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/difference-of-squares/bin/fetch-cobolcheck
+++ b/exercises/practice/difference-of-squares/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/eliuds-eggs/bin/fetch-cobolcheck
+++ b/exercises/practice/eliuds-eggs/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/grade-school/bin/fetch-cobolcheck
+++ b/exercises/practice/grade-school/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/hamming/bin/fetch-cobolcheck
+++ b/exercises/practice/hamming/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/hello-world/bin/fetch-cobolcheck
+++ b/exercises/practice/hello-world/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/high-scores/bin/fetch-cobolcheck
+++ b/exercises/practice/high-scores/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/isogram/bin/fetch-cobolcheck
+++ b/exercises/practice/isogram/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/knapsack/bin/fetch-cobolcheck
+++ b/exercises/practice/knapsack/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/leap/bin/fetch-cobolcheck
+++ b/exercises/practice/leap/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/luhn/bin/fetch-cobolcheck
+++ b/exercises/practice/luhn/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/matching-brackets/bin/fetch-cobolcheck
+++ b/exercises/practice/matching-brackets/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/meetup/bin/fetch-cobolcheck
+++ b/exercises/practice/meetup/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/nucleotide-count/bin/fetch-cobolcheck
+++ b/exercises/practice/nucleotide-count/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/pangram/bin/fetch-cobolcheck
+++ b/exercises/practice/pangram/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/pascals-triangle/bin/fetch-cobolcheck
+++ b/exercises/practice/pascals-triangle/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/pig-latin/bin/fetch-cobolcheck
+++ b/exercises/practice/pig-latin/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/protein-translation/bin/fetch-cobolcheck
+++ b/exercises/practice/protein-translation/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/queen-attack/bin/fetch-cobolcheck
+++ b/exercises/practice/queen-attack/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/raindrops/bin/fetch-cobolcheck
+++ b/exercises/practice/raindrops/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/reverse-string/bin/fetch-cobolcheck
+++ b/exercises/practice/reverse-string/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/rna-transcription/bin/fetch-cobolcheck
+++ b/exercises/practice/rna-transcription/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/robot-simulator/bin/fetch-cobolcheck
+++ b/exercises/practice/robot-simulator/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/roman-numerals/bin/fetch-cobolcheck
+++ b/exercises/practice/roman-numerals/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/rotational-cipher/bin/fetch-cobolcheck
+++ b/exercises/practice/rotational-cipher/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/scrabble-score/bin/fetch-cobolcheck
+++ b/exercises/practice/scrabble-score/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/secret-handshake/bin/fetch-cobolcheck
+++ b/exercises/practice/secret-handshake/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/sieve/bin/fetch-cobolcheck
+++ b/exercises/practice/sieve/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/space-age/bin/fetch-cobolcheck
+++ b/exercises/practice/space-age/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/square-root/bin/fetch-cobolcheck
+++ b/exercises/practice/square-root/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/triangle/bin/fetch-cobolcheck
+++ b/exercises/practice/triangle/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/two-fer/bin/fetch-cobolcheck
+++ b/exercises/practice/two-fer/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"

--- a/exercises/practice/yacht/bin/fetch-cobolcheck
+++ b/exercises/practice/yacht/bin/fetch-cobolcheck
@@ -45,7 +45,7 @@ get_download_url() {
 }
 
 main() {
-  output_path="/usr/local/bin/cobolcheck${ext}"
+  output_path="cobolcheck${ext}"
   download_url="$(get_download_url)"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
   chmod +x "${output_path}"


### PR DESCRIPTION
`test.sh` checks if `bin/cobolcheck` exists. If not, the result of `bin/fetch-cobolcheck` must be `bin/cobolcheck`, not `/usr/local/bin/cobolcheck`.