### PR TITLE
Update `actions/cache` in Windows test CI

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache GnuCOBOL
         id: cache-gnu-cobol
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@640a1c2554105b57832a23eea0b4672fc7a790d5
         with:
           path: |
             ~/gnucobol


### PR DESCRIPTION
Related to #169. This moves `actions/cache` to v4 because the previous version used has been sunset.

https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612/20