### PR TITLE
Binary Search: Resolve the error about WS-ARRAY.

### DIFF
--- a/exercises/practice/binary-search/src/binary-search.cob
+++ b/exercises/practice/binary-search/src/binary-search.cob
@@ -7,9 +7,7 @@
        01 WS-RESULT                PIC 99.
        01 WS-ERROR                 PIC X(40).
        01 WS-COUNT                 PIC 99.       
-       01 WS-ARRAY-TABLE. 
-         02 WS-ARRAY               OCCURS 1 TO 20 DEPENDING ON WS-COUNT.
-            05 ROWELEM             PIC 9(4).       
+       01 WS-ARRAY                 PIC X(60).
 
        PROCEDURE DIVISION.
        


### PR DESCRIPTION
- While the test assumes that WS-ARRAY is a string, the template cobol code delcared it as an integer array. The revised template now declares WS-ARRAY as a string.